### PR TITLE
회원가입 오류 & 소셜 아이디 닉네임 요구 오류 해결

### DIFF
--- a/festiveServer/src/main/java/com/project/festive/festiveserver/member/entity/Member.java
+++ b/festiveServer/src/main/java/com/project/festive/festiveserver/member/entity/Member.java
@@ -80,6 +80,7 @@ public class Member {
 	private String role;
 
 	@Column(name = "MEMBER_DEL_FL", nullable = false)
-	private String memberDelFl;
+	@Builder.Default
+	private String memberDelFl = "N";
 
 }


### PR DESCRIPTION
- 회원가입 시 멤버 탈퇴 여부가 default 값으로 안 들어가서 null 에러나던 거 Builder.default로 해결
- 인증(Authentication) 정보로부터 닉네임을 불러와서 항상 null로 들어와 글 작성, 댓글 작성 불가했던 문제 DB 조회로 변경해서 해결